### PR TITLE
Change maintainers field in metadata for a valid email

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -24,7 +24,7 @@ description: |
 docs: ""
 issues: https://github.com/canonical/saml-integrator-operator/issues
 maintainers:
-  - arturo.seijas@canonical.com
+  - https://launchpad.net/~canonical-is-devops
 source: https://github.com/canonical/saml-integrator-operator
 assumes:
   - k8s-api

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -24,7 +24,7 @@ description: |
 docs: ""
 issues: https://github.com/canonical/saml-integrator-operator/issues
 maintainers:
-  - launchpad.net/~canonical-is-devops
+  - arturo.seijas@canonical.com
 source: https://github.com/canonical/saml-integrator-operator
 assumes:
   - k8s-api


### PR DESCRIPTION
As per https://discourse.charmhub.io/t/inquiry-about-released-charm-not-being-reachable/11279/3, the `maintainers` field needs to be a valid link