### PR TITLE
Allow deploying on substrates different from k8s

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -26,8 +26,6 @@ issues: https://github.com/canonical/saml-integrator-operator/issues
 maintainers:
   - launchpad.net/~canonical-is-devops
 source: https://github.com/canonical/saml-integrator-operator
-assumes:
-  - k8s-api
 provides:
   saml:
     interface: saml


### PR DESCRIPTION
Allow deploying the charm on substrates different from k8s