### PR TITLE
Update relation data on update status event

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -50,21 +50,21 @@ class SamlIntegratorOperatorCharm(ops.CharmBase):
         """Handle a change to the saml relation."""
         # A new charm will be instantiated hence, the information will be fetched again.
         # The relation databags are rewritten in case there are changes.
-        self._update_all_relations()
+        self._update_relations()
 
     def _on_update_status(self, _) -> None:
         """Handle the update status event."""
         # A new charm will be instantiated hence, the information will be fetched again.
         # The relation databags are rewritten in case there are changes.
-        self._update_all_relations()
+        self._update_relations()
 
     def _on_config_changed(self, _) -> None:
         """Handle changes in configuration."""
         self.unit.status = ops.MaintenanceStatus("Configuring charm")
-        self._update_all_relations()
+        self._update_relations()
         self.unit.status = ops.ActiveStatus()
 
-    def _update_all_relations(self) -> None:
+    def _update_relations(self) -> None:
         """Update all SAML data for the existing relations."""
         if not self.model.unit.is_leader():
             return

--- a/src/charm.py
+++ b/src/charm.py
@@ -39,6 +39,7 @@ class SamlIntegratorOperatorCharm(ops.CharmBase):
         self.framework.observe(self.on[RELATION_NAME].relation_created, self._on_relation_created)
         self.framework.observe(self.on.config_changed, self._on_config_changed)
         self.framework.observe(self.on.upgrade_charm, self._on_upgrade_charm)
+        self.framework.observe(self.on.update_status, self._on_update_status)
 
     def _on_upgrade_charm(self, _) -> None:
         """Install needed apt packages."""
@@ -47,8 +48,12 @@ class SamlIntegratorOperatorCharm(ops.CharmBase):
 
     def _on_relation_created(self, _) -> None:
         """Handle a change to the saml relation."""
-        if not self.model.unit.is_leader():
-            return
+        # A new charm will be instantiated hence, the information will be fetched again.
+        # The relation databags are rewritten in case there are changes.
+        self._update_all_relations()
+
+    def _on_update_status(self, _) -> None:
+        """Handle the update status event."""
         # A new charm will be instantiated hence, the information will be fetched again.
         # The relation databags are rewritten in case there are changes.
         self._update_all_relations()
@@ -56,12 +61,13 @@ class SamlIntegratorOperatorCharm(ops.CharmBase):
     def _on_config_changed(self, _) -> None:
         """Handle changes in configuration."""
         self.unit.status = ops.MaintenanceStatus("Configuring charm")
-        if self.model.unit.is_leader():
-            self._update_all_relations()
+        self._update_all_relations()
         self.unit.status = ops.ActiveStatus()
 
     def _update_all_relations(self) -> None:
         """Update all SAML data for the existing relations."""
+        if not self.model.unit.is_leader():
+            return
         for relation in self.saml.relations:
             self.saml.update_relation_data(relation, self.get_saml_data())
 


### PR DESCRIPTION
An Update status event will instantiate a new charm, effectively fetching the metadata again. When that occurs, the relation databags are updated to propagate the changes