### PR TITLE
Emit data available event only if the saml data is present

### DIFF
--- a/lib/charms/saml_integrator/v0/saml.py
+++ b/lib/charms/saml_integrator/v0/saml.py
@@ -66,7 +66,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 # pylint: disable=wrong-import-position
 import re
@@ -263,7 +263,9 @@ class SamlRequires(ops.Object):
         """
         if not self.charm.unit.is_leader():
             return
-        self.on.saml_data_available.emit(event.relation, app=event.app, unit=event.unit)
+        assert event.relation.app
+        if event.relation.data[event.relation.app]:
+            self.on.saml_data_available.emit(event.relation, app=event.app, unit=event.unit)
 
 
 class SamlProvides(ops.Object):

--- a/tests/unit/test_library_saml.py
+++ b/tests/unit/test_library_saml.py
@@ -140,6 +140,22 @@ def test_requirer_charm_does_not_emit_event_id_no_leader():
     assert len(harness.charm.events) == 0
 
 
+def test_requirer_charm_does_not_emit_event_id_no_data():
+    """
+    arrange: set up a charm with no relation data to be populated.
+    act: trigger a relation changed event.
+    assert: no events are emitted.
+    """
+    harness = Harness(SamlRequirerCharm, meta=REQUIRER_METADATA)
+    harness.begin()
+    harness.set_leader(True)
+    relation_id = harness.add_relation("saml", "saml-provider")
+    harness.add_relation_unit(relation_id, "saml-provider/0")
+    relation = harness.charm.framework.model.get_relation("saml", 0)
+    harness.charm.on.saml_relation_changed.emit(relation)
+    assert len(harness.charm.events) == 0
+
+
 def test_requirer_charm_emits_event_when_leader():
     """
     arrange: set up a charm with leadership.


### PR DESCRIPTION
Emit data available event only if the saml data is present. Otherwise, events without relation data can be emitted if the charm is blocked