### PR TITLE
Change fingerprint config description

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -7,7 +7,9 @@ options:
     description: Identifier of the IdP entity (must be a URI)
   fingerprint:
     type: string
-    description: SHA256 Fingerprint to validate the metadata's certificate. If empty, no validation is performed
+    description: |
+      SHA256 Fingerprint to validate the metadata's certificate. If empty, no validation is 
+      performed. Setting a value will also check if the whole metadata is signed.
   metadata_url:
     type: string
     description: URL to the IdP's metadata

--- a/src/saml.py
+++ b/src/saml.py
@@ -91,6 +91,9 @@ class SamlIntegrator:  # pylint: disable=import-outside-toplevel
             raise CharmConfigInvalidError("The metadata signature does not match the provided one")
         tree = self._read_tree()
         if self.signing_certificate and self.signature:
+            # The metadata can be tampered unless the metadata contents used are signed. To prevent
+            # this, instead of arbitrarily validating all fragments that can be shared with the
+            # requirer, the whole contents are validated.
             try:
                 signxml.XMLVerifier().verify(tree, x509_cert=self.signing_certificate)
             except signxml.exceptions.InvalidSignature as ex:

--- a/src/saml.py
+++ b/src/saml.py
@@ -92,8 +92,8 @@ class SamlIntegrator:  # pylint: disable=import-outside-toplevel
         tree = self._read_tree()
         if self.signing_certificate and self.signature:
             # The metadata can be tampered unless the metadata contents used are signed. To prevent
-            # this, instead of arbitrarily validating all fragments that can be shared with the
-            # requirer, the whole contents are validated.
+            # this, instead of arbitrarily validating the signature for all fragments that can be
+            # shared with the requirer, the whole contents will need to be signed.
             try:
                 signxml.XMLVerifier().verify(tree, x509_cert=self.signing_certificate)
             except signxml.exceptions.InvalidSignature as ex:


### PR DESCRIPTION
Add additional comments to explain how metadata signature validation works.
The SAML spec doesn't enforce which contents need to be signed and the responsibility of validating the pieces that will be used by the SP relies on itself.