### PR TITLE
Register start handler also when config is invalid

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -29,6 +29,7 @@ class SamlIntegratorOperatorCharm(ops.CharmBase):
             args: Arguments passed to the CharmBase parent constructor.
         """
         super().__init__(*args)
+        self.framework.observe(self.on.start, self._on_start)
         try:
             self._charm_state = CharmState.from_charm(charm=self)
             self._saml_integrator = SamlIntegrator(charm_state=self._charm_state)
@@ -38,7 +39,6 @@ class SamlIntegratorOperatorCharm(ops.CharmBase):
         self.saml = saml.SamlProvides(self)
         self.framework.observe(self.on[RELATION_NAME].relation_created, self._on_relation_created)
         self.framework.observe(self.on.config_changed, self._on_config_changed)
-        self.framework.observe(self.on.start, self._on_start)
         self.framework.observe(self.on.update_status, self._on_update_status)
 
     def _on_start(self, _) -> None:

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -37,6 +37,7 @@ async def test_relation(ops_test: OpsTest, app: ops.Application, any_charm: ops.
     Assume that the charm has already been built and is running.
     """
     relation_name = f"{app.name}:saml"
+    assert ops_test.model
     await ops_test.model.add_relation(any_charm.name, relation_name)
     await app.set_config(  # type: ignore[attr-defined]
         {
@@ -45,7 +46,6 @@ async def test_relation(ops_test: OpsTest, app: ops.Application, any_charm: ops.
             "metadata_url": "https://login.staging.ubuntu.com/saml/metadata",
         }
     )
-    assert ops_test.model
     status_name = ops.ActiveStatus.name  # type: ignore[has-type]
     await ops_test.model.wait_for_idle(status=status_name, raise_on_error=True)
     assert app.units[0].workload_status == status_name  # type: ignore

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -36,6 +36,8 @@ async def test_relation(ops_test: OpsTest, app: ops.Application, any_charm: ops.
 
     Assume that the charm has already been built and is running.
     """
+    relation_name = f"{app.name}:saml"
+    await ops_test.model.add_relation(any_charm.name, relation_name)
     await app.set_config(  # type: ignore[attr-defined]
         {
             "entity_id": "https://login.staging.ubuntu.com",
@@ -43,11 +45,7 @@ async def test_relation(ops_test: OpsTest, app: ops.Application, any_charm: ops.
             "metadata_url": "https://login.staging.ubuntu.com/saml/metadata",
         }
     )
-    status_name = ops.ActiveStatus.name  # type: ignore[has-type]
     assert ops_test.model
-    await ops_test.model.wait_for_idle(status=status_name, raise_on_error=True)
-    assert app.units[0].workload_status == status_name  # type: ignore
-    relation_name = f"{app.name}:saml"
-    await ops_test.model.add_relation(any_charm.name, relation_name)
+    status_name = ops.ActiveStatus.name  # type: ignore[has-type]
     await ops_test.model.wait_for_idle(status=status_name, raise_on_error=True)
     assert app.units[0].workload_status == status_name  # type: ignore


### PR DESCRIPTION
The start handler is currently not registered when a charm is deployed without a proper configuration and this is fixed later