### PR TITLE
Install packages as part of the install hook to ensure they're available before any other hooks fire

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -29,7 +29,7 @@ class SamlIntegratorOperatorCharm(ops.CharmBase):
             args: Arguments passed to the CharmBase parent constructor.
         """
         super().__init__(*args)
-        self.framework.observe(self.on.start, self._on_start)
+        self.framework.observe(self.on.install, self._on_install)
         try:
             self._charm_state = CharmState.from_charm(charm=self)
             self._saml_integrator = SamlIntegrator(charm_state=self._charm_state)
@@ -41,7 +41,7 @@ class SamlIntegratorOperatorCharm(ops.CharmBase):
         self.framework.observe(self.on.config_changed, self._on_config_changed)
         self.framework.observe(self.on.update_status, self._on_update_status)
 
-    def _on_start(self, _) -> None:
+    def _on_install(self, _) -> None:
         """Install needed apt packages."""
         self.unit.status = ops.MaintenanceStatus("Installing packages")
         apt.add_package(["libssl-dev", "libxml2", "libxslt1-dev"], update_cache=True)

--- a/tests/interface/conftest.py
+++ b/tests/interface/conftest.py
@@ -23,11 +23,11 @@ from charm import SamlIntegratorOperatorCharm
 # to include the new identifier/location.
 @pytest.fixture
 def interface_tester(interface_tester: InterfaceTester, monkeypatch: pytest.MonkeyPatch):
-    def _on_start_patched(self, _) -> None:
+    def _on_install_patched(self, _) -> None:
         """Patched start event handler."""
         self.unit.status = ops.ActiveStatus()
 
-    monkeypatch.setattr(SamlIntegratorOperatorCharm, "_on_start", _on_start_patched)
+    monkeypatch.setattr(SamlIntegratorOperatorCharm, "_on_install", _on_install_patched)
 
     sso_endpoint = SamlEndpoint(
         name="SingleSignOnService",

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -17,8 +17,8 @@ from charm import SamlIntegratorOperatorCharm
 def test_libs_installed(apt_add_package_mock):
     """
     arrange: set up a charm.
-    act: none.
-    assert: the charm installs libxml2.
+    act: trigger the install event.
+    assert: the charm installs required packages.
     """
     harness = Harness(SamlIntegratorOperatorCharm)
     entity_id = "https://login.staging.ubuntu.com"
@@ -30,7 +30,10 @@ def test_libs_installed(apt_add_package_mock):
         }
     )
     harness.begin()
-    harness.charm.on.start.emit()
+    # First confirm no packages have been installed.
+    apt_add_package_mock.assert_not_called()
+    harness.charm.on.install.emit()
+    # And now confirm we've installed the required packages.
     apt_add_package_mock.assert_called_once_with(
         ["libssl-dev", "libxml2", "libxslt1-dev"], update_cache=True
     )


### PR DESCRIPTION
Applicable spec: N/A

### Overview

We need to ensure any required packages are installed as part of the install hook, so they're available before any other hooks run.

### Rationale

See https://github.com/canonical/saml-integrator-operator/issues/66 for the issue.

### Juju Events Changes

We're switching from observing the start hook to the install hook. See https://juju.is/docs/sdk/charm-lifecycle for hook execution order.

### Module Changes

N/A

### Library Changes

N/A

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
