### PR TITLE
Keep pytest-interface-tester<2

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -107,7 +107,7 @@ description = Run unit tests
 deps =
     pytest
     ops-scenario>=5.3.1
-    pytest-interface-tester>=1.0.4
+    pytest-interface-tester>=1.0.4,<2
 commands =
     pytest -v --tb native {[vars]tst_path}/interface --log-cli-level=INFO -s {posargs}
 


### PR DESCRIPTION
### Overview

As [pytest-interface-tester#13](https://github.com/canonical/pytest-interface-tester/pull/13) upgrades pydantic to v2, limit interface tester dependency to <2 until the project decides to switch to pydantic v2.

### Rationale

We're moving to pydantic v2 in observability charms so interface-tester needs to be upgraded as well.

### Juju Events Changes

None.

### Module Changes

None.

### Library Changes

Only thing that changes is the dependency definition for interface tests.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
No updates in the documentation. Looks like as a non-maintainer I can't tag PRs?
