### PR TITLE
Change lib typing for focal compatibility

### DIFF
--- a/lib/charms/saml_integrator/v0/saml.py
+++ b/lib/charms/saml_integrator/v0/saml.py
@@ -66,11 +66,11 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 4
+LIBPATCH = 5
 
 # pylint: disable=wrong-import-position
 import re
-from typing import Optional
+import typing
 
 import ops
 from pydantic import AnyHttpUrl, BaseModel, Field
@@ -92,15 +92,15 @@ class SamlEndpoint(BaseModel):
     name: str = Field(..., min_length=1)
     url: AnyHttpUrl
     binding: str = Field(..., min_length=1)
-    response_url: Optional[AnyHttpUrl]
+    response_url: typing.Optional[AnyHttpUrl]
 
-    def to_relation_data(self) -> dict[str, str]:
+    def to_relation_data(self) -> typing.Dict[str, str]:
         """Convert an instance of SamlEndpoint to the relation representation.
 
         Returns:
             Dict containing the representation.
         """
-        result: dict[str, str] = {}
+        result: typing.Dict[str, str] = {}
         # Get the HTTP method from the SAML binding
         http_method = self.binding.split(":")[-1].split("-")[-1].lower()
         # Transform name into snakecase
@@ -113,7 +113,7 @@ class SamlEndpoint(BaseModel):
         return result
 
     @classmethod
-    def from_relation_data(cls, relation_data: dict[str, str]) -> "SamlEndpoint":
+    def from_relation_data(cls, relation_data: typing.Dict[str, str]) -> "SamlEndpoint":
         """Initialize a new instance of the SamlEndpoint class from the relation data.
 
         Args:
@@ -157,10 +157,10 @@ class SamlRelationData(BaseModel):
 
     entity_id: str = Field(..., min_length=1)
     metadata_url: AnyHttpUrl
-    certificates: list[str]
-    endpoints: list[SamlEndpoint]
+    certificates: typing.List[str]
+    endpoints: typing.List[SamlEndpoint]
 
-    def to_relation_data(self) -> dict[str, str]:
+    def to_relation_data(self) -> typing.Dict[str, str]:
         """Convert an instance of SamlDataAvailableEvent to the relation representation.
 
         Returns:
@@ -199,13 +199,13 @@ class SamlDataAvailableEvent(ops.RelationEvent):
         return parse_obj_as(AnyHttpUrl, self.relation.data[self.relation.app].get("metadata_url"))
 
     @property
-    def certificates(self) -> tuple[str, ...]:
+    def certificates(self) -> typing.Tuple[str, ...]:
         """Fetch the SAML certificates from the relation."""
         assert self.relation.app
         return tuple(self.relation.data[self.relation.app].get("x509certs").split(","))
 
     @property
-    def endpoints(self) -> tuple[SamlEndpoint, ...]:
+    def endpoints(self) -> typing.Tuple[SamlEndpoint, ...]:
         """Fetch the SAML endpoints from the relation."""
         assert self.relation.app
         relation_data = self.relation.data[self.relation.app]
@@ -287,7 +287,7 @@ class SamlProvides(ops.Object):
         self.relation_name = relation_name
 
     @property
-    def relations(self) -> list[ops.Relation]:
+    def relations(self) -> typing.List[ops.Relation]:
         """The list of Relation instances associated with this relation_name.
 
         Returns:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -52,6 +52,6 @@ async def any_charm(ops_test: OpsTest):
         "any-charm",
         application_name="any",
         channel="beta",
-        config={"src-overwrite": json.dumps(src_overwrite)},
+        config={"python-packages": "pydantic<2.0", "src-overwrite": json.dumps(src_overwrite)},
     )
     yield application


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Change type hints from the lib in order to enforce compatibility with Focal

### Rationale

This change is needed to integrate SAML to Discourse deploments in Focal

### Juju Events Changes

N/A

### Module Changes

N/A

### Library Changes

Change some conflicting type hints.

### Checklist

- [X] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [X] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [X] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [X] The documentation is generated using `src-docs`
- [X] The documentation for charmhub is updated
- [X] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
