### PR TITLE
Add method to the requirer to retrieve relation data

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -8,5 +8,6 @@ jobs:
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
     secrets: inherit
     with:
+      channel: 1.29-strict/stable
       juju-channel: 3.1/stable
       trivy-fs-enabled: true

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -8,4 +8,5 @@ jobs:
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
     secrets: inherit
     with:
+      juju-channel: 3.1/stable
       trivy-fs-enabled: true

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -8,6 +8,6 @@ jobs:
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
     secrets: inherit
     with:
-      channel: 1.29-strict/stable
+      channel: 1.27-strict/stable
       juju-channel: 3.1/stable
       trivy-fs-enabled: true

--- a/lib/charms/saml_integrator/v0/saml.py
+++ b/lib/charms/saml_integrator/v0/saml.py
@@ -68,7 +68,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 7
 
 # pylint: disable=wrong-import-position
 import re
@@ -289,6 +289,18 @@ class SamlRequires(ops.Object):
         assert event.relation.app
         if event.relation.data[event.relation.app]:
             self.on.saml_data_available.emit(event.relation, app=event.app, unit=event.unit)
+
+    def get_relation_data(self) -> typing.Optional[SamlRelationData]:
+        """Retrieve the relation data.
+
+        Returns:
+            SmtpRelationData: the relation data.
+        """
+        relation = self.model.get_relation(self.relation_name)
+        assert relation
+        assert relation.data
+        assert relation.app
+        return SamlRelationData.from_relation_data(relation.data[relation.app])
 
 
 class SamlProvides(ops.Object):

--- a/lib/charms/saml_integrator/v0/saml.py
+++ b/lib/charms/saml_integrator/v0/saml.py
@@ -297,7 +297,8 @@ class SamlRequires(ops.Object):
             SmtpRelationData: the relation data.
         """
         relation = self.model.get_relation(self.relation_name)
-        assert relation
+        if not relation:
+            return None
         assert relation.data
         assert relation.app
         return SamlRelationData.from_relation_data(relation.data[relation.app])

--- a/tests/unit/test_library_saml.py
+++ b/tests/unit/test_library_saml.py
@@ -172,3 +172,9 @@ def test_requirer_charm_emits_event(is_leader):
     assert harness.charm.events[0].metadata_url == relation_data["metadata_url"]
     assert harness.charm.events[0].certificates == tuple(relation_data["x509certs"].split(","))
     assert harness.charm.events[0].endpoints == (slo_endpoint, sso_endpoint)
+
+    retrieved_relation_data = harness.charm.saml.get_relation_data()
+    assert retrieved_relation_data.entity_id == relation_data["entity_id"]
+    assert retrieved_relation_data.metadata_url == relation_data["metadata_url"]
+    assert retrieved_relation_data.certificates == tuple(relation_data["x509certs"].split(","))
+    assert retrieved_relation_data.endpoints == (slo_endpoint, sso_endpoint)

--- a/tox.ini
+++ b/tox.ini
@@ -114,7 +114,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    juju==2.9.42.4
+    juju==3.3.1.1
     pytest
     pytest-asyncio
     pytest-operator

--- a/tox.ini
+++ b/tox.ini
@@ -114,7 +114,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    juju
+    juju==2.9.46.1
     pytest
     pytest-asyncio
     pytest-operator

--- a/tox.ini
+++ b/tox.ini
@@ -114,7 +114,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    juju==2.9.46.1
+    juju
     pytest
     pytest-asyncio
     pytest-operator

--- a/tox.ini
+++ b/tox.ini
@@ -114,7 +114,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    juju==3.3.1.1
+    juju
     pytest
     pytest-asyncio
     pytest-operator


### PR DESCRIPTION
Applicable spec: <link> N/a

### Overview

<!-- A high level overview of the change -->
Add method to the requirer to retrieve relation data for improved UX

### Rationale

<!-- The reason the change is needed -->
N/A

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->
N/A

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->
N/A

### Library Changes

<!-- Any changes to charm libraries -->
saml.py

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
