### PR TITLE
Fix link to charm configuration

### DIFF
--- a/docs/how-to/configure-saml.md
+++ b/docs/how-to/configure-saml.md
@@ -4,4 +4,4 @@ To configure the SAML Integrator integration you'll have to set the following co
 
 Two configuration values are mandatory, the SAML metadata URL that needs to be specified in `metadata_url` and the entity ID, in `entity_id`.
 
-For more details on the configuration options and their default values see the [configuration reference](https://charmhub.io/saml-integrator/configure).
+For more details on the configuration options and their default values see the [configuration reference](https://charmhub.io/saml-integrator/configuration).


### PR DESCRIPTION
Applicable spec: N/A
### Overview

Trivial doc change fixing link to configuration.

### Rationale

To fix docs link.

### Juju Events Changes

N/A

### Module Changes

N/A

### Library Changes

N/A

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
