### PR TITLE
Support configuring the metadata directly

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -10,6 +10,9 @@ options:
     description: |
       SHA256 Fingerprint to validate the metadata's certificate. If empty, no validation is 
       performed. Setting a value will also check if the whole metadata is signed.
+  metadata:
+    type: string
+    description: The IdP's metadata. This configuration has effect only if `metadata_url` is not defined.
   metadata_url:
     type: string
     description: URL to the IdP's metadata

--- a/src/charm_state.py
+++ b/src/charm_state.py
@@ -6,6 +6,7 @@
 """Module defining the CharmState class which represents the state of the SAML Integrator charm."""
 
 import itertools
+import urllib
 from typing import Optional
 
 import ops
@@ -16,14 +17,16 @@ class SamlIntegratorConfig(BaseModel):  # pylint: disable=too-few-public-methods
     """Represent charm builtin configuration values.
 
     Attrs:
-        entity_id: Entity ID.
+        entity_id: entity ID.
         fingerprint: fingerprint to validate the signing certificate against.
-        metadata_url: Metadata URL.
+        metadata: metadata.
+        metadata_url: metadata URL.
     """
 
     entity_id: str = Field(..., min_length=1)
     fingerprint: Optional[str]
-    metadata_url: AnyHttpUrl
+    metadata: Optional[str]
+    metadata_url: Optional[AnyHttpUrl]
 
 
 class CharmConfigInvalidError(Exception):
@@ -48,6 +51,7 @@ class CharmState:
     Attrs:
         entity_id: Entity ID for SAML.
         fingerprint: fingerprint to validate the signing certificate against.
+        metadata: metadata.
         metadata_url: URL for the SAML metadata.
     """
 
@@ -78,13 +82,34 @@ class CharmState:
         return self._saml_integrator_config.fingerprint
 
     @property
-    def metadata_url(self) -> str:
+    def metadata_url(self) -> Optional[str]:
         """Return metadata_url config.
 
         Returns:
             str: metadata_url config.
         """
         return self._saml_integrator_config.metadata_url
+
+    @property
+    def metadata(self) -> str:
+        """Return metadata config or metadata_url content.
+
+        Returns:
+            str: metadata.
+        """
+        if self._saml_integrator_config.metadata_url:
+            try:
+                with urllib.request.urlopen(
+                    self._saml_integrator_config.metadata_url, timeout=10
+                ) as resource:  # nosec
+                    return resource.read()
+            except urllib.error.URLError as ex:
+                raise CharmConfigInvalidError(
+                    f"Error while retrieving data from {self.metadata_url}"
+                ) from ex
+        # Config will be identified as invalid is neither metadata_url nor metadata are defined.
+        assert self._saml_integrator_config.metadata  # nosec
+        return self._saml_integrator_config.metadata
 
     @classmethod
     def from_charm(cls, charm: "ops.CharmBase") -> "CharmState":
@@ -102,6 +127,10 @@ class CharmState:
         try:
             # Incompatible with pydantic.AnyHttpUrl
             valid_config = SamlIntegratorConfig(**dict(charm.config.items()))  # type: ignore
+            if not valid_config.metadata_url and not valid_config.metadata:
+                raise CharmConfigInvalidError(
+                    "Either the metadata_url or the metadata need to be configured."
+                )
         except ValidationError as exc:
             error_fields = set(
                 itertools.chain.from_iterable(error["loc"] for error in exc.errors())

--- a/src/saml.py
+++ b/src/saml.py
@@ -6,7 +6,6 @@ import base64
 import hashlib
 import logging
 import secrets
-import urllib.request
 from functools import cached_property
 from typing import TYPE_CHECKING, Optional
 
@@ -55,20 +54,9 @@ class SamlIntegrator:  # pylint: disable=import-outside-toplevel
         from lxml import etree  # nosec
 
         try:
-            with urllib.request.urlopen(
-                self._charm_state.metadata_url, timeout=10
-            ) as resource:  # nosec
-                raw_data = resource.read()
-                tree = etree.fromstring(raw_data)  # nosec
-                return tree
-        except urllib.error.URLError as ex:
-            raise CharmConfigInvalidError(
-                f"Error while retrieving data from {self._charm_state.metadata_url}"
-            ) from ex
+            return etree.fromstring(self._charm_state.metadata)  # nosec
         except etree.XMLSyntaxError as ex:
-            raise CharmConfigInvalidError(
-                f"Data from {self._charm_state.metadata_url} can't be parsed"
-            ) from ex
+            raise CharmConfigInvalidError("Metadata can't be parsed") from ex
 
     @cached_property
     def tree(self) -> "etree.ElementTree":

--- a/tests/unit/test_charm_state.py
+++ b/tests/unit/test_charm_state.py
@@ -2,20 +2,29 @@
 # See LICENSE file for licensing details.
 
 """CharmState unit tests."""
-
-from unittest.mock import MagicMock
+import urllib
+from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from charm_state import CharmConfigInvalidError, CharmState
 
 
-def test_charm_state_from_charm():
+@patch("urllib.request.urlopen")
+def test_charm_state_from_charm_with_metadata_url(urlopen_mock):
     """
     arrange: set up a configured charm
     act: access the status properties
     assert: the configuration is accessible from the state properties.
     """
+    metadata = Path("tests/unit/files/metadata_unsigned.xml").read_bytes()
+    urlopen_result_mock = MagicMock()
+    urlopen_result_mock.getcode.return_value = 200
+    urlopen_result_mock.read.return_value = metadata
+    urlopen_result_mock.__enter__.return_value = urlopen_result_mock
+    urlopen_mock.return_value = urlopen_result_mock
+
     entity_id = "https://login.staging.ubuntu.com"
     metadata_url = "https://login.staging.ubuntu.com/saml/metadata"
     charm = MagicMock(
@@ -27,6 +36,28 @@ def test_charm_state_from_charm():
     state = CharmState.from_charm(charm)
     assert state.entity_id == entity_id
     assert state.metadata_url == metadata_url
+    assert state.metadata == metadata
+
+
+def test_charm_state_from_charm_with_metadata():
+    """
+    arrange: set up a configured charm
+    act: access the status properties
+    assert: the configuration is accessible from the state properties.
+    """
+    metadata = Path("tests/unit/files/metadata_unsigned.xml").read_text(encoding="utf-8")
+
+    entity_id = "https://login.staging.ubuntu.com"
+    charm = MagicMock(
+        config={
+            "entity_id": entity_id,
+            "metadata": metadata,
+        }
+    )
+    state = CharmState.from_charm(charm)
+    assert state.entity_id == entity_id
+    assert state.metadata_url is None
+    assert state.metadata == metadata
 
 
 def test_charm_state_from_charm_with_invalid_config():
@@ -35,6 +66,27 @@ def test_charm_state_from_charm_with_invalid_config():
     act: access the status properties
     assert: a CharmConfigInvalidError is raised.
     """
-    charm = MagicMock(config={})
+    entity_id = "https://login.staging.ubuntu.com"
+    charm = MagicMock(config={"entity_id": entity_id})
     with pytest.raises(CharmConfigInvalidError):
         CharmState.from_charm(charm)
+
+
+@patch.object(urllib.request, "urlopen", side_effect=urllib.error.URLError("Error"))
+def test_charm_state_from_charm_with_metadata_url_invalid(_):
+    """
+    arrange: set up a configured charm with a metadata_url returning a 404
+    act: access the status properties
+    assert: a CharmConfigInvalidError is raised.
+    """
+    entity_id = "https://login.staging.ubuntu.com"
+    metadata_url = "https://login.staging.ubuntu.com/saml/metadata"
+    charm = MagicMock(
+        config={
+            "entity_id": entity_id,
+            "metadata_url": metadata_url,
+        }
+    )
+    state = CharmState.from_charm(charm)
+    with pytest.raises(CharmConfigInvalidError):
+        state.metadata  # pylint: disable=pointless-statement

--- a/tests/unit/test_saml.py
+++ b/tests/unit/test_saml.py
@@ -3,8 +3,8 @@
 
 """SAML Integrator unit tests."""
 # pylint: disable=pointless-statement
-import urllib
-from unittest.mock import MagicMock, patch
+from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -28,20 +28,16 @@ def get_urlopen_result_mock(code: int, result: bytes) -> MagicMock:
     return urlopen_result_mock
 
 
-@patch("urllib.request.urlopen")
-def test_saml_with_invalid_metadata(urlopen_mock):
+def test_saml_with_invalid_metadata():
     """
     arrange: mock the metadata contents so that they are invalid.
     act: access the metadata properties.
     assert: a CharmConfigInvalidError exception is raised when attempting to access the
         properties read from the metadata.
     """
-    urlopen_result_mock = get_urlopen_result_mock(200, b"invalid")
-    urlopen_result_mock.__enter__.return_value = urlopen_result_mock
-    urlopen_mock.return_value = urlopen_result_mock
     charm_state = MagicMock(
         entity_id="https://login.staging.ubuntu.com",
-        metadata_url="https://login.staging.ubuntu.com/saml/metadata",
+        metadata="invalid",
     )
     saml_integrator = SamlIntegrator(charm_state=charm_state)
     with pytest.raises(CharmConfigInvalidError):
@@ -50,255 +46,206 @@ def test_saml_with_invalid_metadata(urlopen_mock):
         saml_integrator.endpoints
 
 
-@patch.object(urllib.request, "urlopen", side_effect=urllib.error.URLError("Error"))
-def test_saml_with_invalid_url(_):
-    """
-    arrange: mock the HTTP request for the metadata so that it fails.
-    act: access the metadata properties.
-    assert: a CharmConfigInvalidError exception is raised when attempting to access the
-        properties read from the metadata.
-    """
-    charm_state = MagicMock(
-        entity_id="https://login.staging.ubuntu.com",
-        metadata_url="https://login.staging.ubuntu.com/saml/metadata",
-    )
-    saml_integrator = SamlIntegrator(charm_state=charm_state)
-    with pytest.raises(CharmConfigInvalidError):
-        saml_integrator.certificates
-    with pytest.raises(CharmConfigInvalidError):
-        saml_integrator.endpoints
-
-
-@patch("urllib.request.urlopen")
-def test_saml_with_valid_signed_metadata(urlopen_mock):
+def test_saml_with_valid_signed_metadata():
     """
     arrange: mock the metadata contents so that they valid.
     act: access the metadata properties.
     assert: the properties are populated as defined in the metadata.
     """
-    with open("tests/unit/files/metadata_signed.xml", "rb") as metadata:
-        urlopen_result_mock = get_urlopen_result_mock(200, metadata.read())
-        urlopen_result_mock.__enter__.return_value = urlopen_result_mock
-        urlopen_mock.return_value = urlopen_result_mock
-
-        entity_id = "https://login.staging.ubuntu.com"
-        metadata_url = "https://login.staging.ubuntu.com/saml/metadata"
-        charm_state = MagicMock(
-            entity_id=entity_id,
-            fingerprint=(
-                "1C:73:51:f2:23:55:f8:3d:25:7e:65:56:dd:f1:a9:17:fe:d4:af"
-                ":dc:70:d2:a8:11:b3:2f:d2:ea:c4:6d:91:e7"
-            ),
-            metadata_url=metadata_url,
-        )
-        saml_integrator = SamlIntegrator(charm_state=charm_state)
-        signing_cert = (
-            "MIIFazCCA1OgAwIBAgIUWPY90f+xbkCWHVJXtwm2+9mZiIcwDQYJKoZIhvcNAQEL"
-            "BQAwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoM"
-            "GEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDAeFw0yMzA4MDkxNDI1NDVaFw0yNDA4"
-            "MDgxNDI1NDVaMEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEw"
-            "HwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwggIiMA0GCSqGSIb3DQEB"
-            "AQUAA4ICDwAwggIKAoICAQDDaJTOlLBVePVvenKbtq6B6vHNnvxLEA1NMmhZ9yvH"
-            "N/h0/FTph0iBf+VWyCY9M2CeMKggTIAhrVAXEALG7ImGl/lFKdfC/8eEXFtEMe4V"
-            "WAOC9qnb3dAViMAq5xMd6e5gwrcPSaDtOE8Up2OUfsHuf7GfocWtWh3beqW1FLE7"
-            "JBPcVKNZ6T8ap5fUHVCprfCk0yrPQ3ocJOWE0JHatqfahU34fWFTHWD1qfplL/Xf"
-            "mr9ayk+eey2FwsoloEtdpOMgitkeYpKNTh4btkQ4TEyKlG07+87l1b7niBeuEj1T"
-            "yqq87Kz6eHIarAlLmPHhBuM1/BQunyaVEfM0AXv2u/A8Uvz9njRoaWlZKHdlsEMq"
-            "hBzVCn+T7WnkxE3dGQDwgXbeDIOx1x/utR40UZeYUd6HUer4WtORNg1pBp2GeKp8"
-            "3gej/SjAhzqsB3ZdhPA47bDw21sp4ytTPCEvc2IsdErq7zIe5pUxkQKOe0R00qyd"
-            "69THdTqjvpo6oVQdEXauCisooWwxRAksUazqtaZUAwNB/pLqmE+kSFnsxEpn6BDH"
-            "6GVUFfMpzXUTsqBqK3j5QvHexVzLp3CyYicq1VjKghu5ICsIp+CGhLEEIBLJksJ8"
-            "IH6j9mHJ4W4qoLefBHNZDlxg2ZGDwEqs66gJVao5zQyEDjScUjVTrvfIZM3WY08L"
-            "5QIDAQABo1MwUTAdBgNVHQ4EFgQUW/f6Ya3dlETc60m8JFhZsZo4XLYwHwYDVR0j"
-            "BBgwFoAUW/f6Ya3dlETc60m8JFhZsZo4XLYwDwYDVR0TAQH/BAUwAwEB/zANBgkq"
-            "hkiG9w0BAQsFAAOCAgEAocRH2K+CWQFxMpJQvayEq7uU6dkdH2xE12Vg4wUm4/h+"
-            "hmngK6TlXqBHISpitlQlbqx1CsO3E9FeZGVA7erySh+lyoO9Hndhm7Fsj2U1P0MW"
-            "tkz81NOT975f0zTQ1KsdzTHkocV5dx869jD3ssUCkpxdTRF6EJmRLQoRfGEmxnuG"
-            "bynFcOUMZ7fxd79IsDy4tWcUjoV4jeWDiyi/LuuhVDr+AhI62Gl2MTdFLHTTRzak"
-            "IzIWmFVEdrfuDgg/RR4YYBoXrGSA0RLrpKpexb4kZd8/hvTtCcPghUuK6Q1iMT4q"
-            "hV2dKVFut/6IKLnD35Ol/fLLoy2CtnioUqx6v3MefxAptKpQM3ebgpv2UzIsIXdU"
-            "RQ9pfDlsyo1wdJ1wZNh6A5eerROsX3MKjLqUAiJh4v+ydeR3IyN3YckdadU6Wq+m"
-            "wnrVPI0nxrgLW/5srJ4cR4idEgmV8cRNJSqoaFPLyBoLk/cjq/yQAXcz23eWD6aD"
-            "qsOrRlyuKXQ6KEi/z6aIsiKNH5PPg9Fr3aH+cSnbTU7UNmJH/eOaYzaYMI1NiweU"
-            "Z5C+jLxosbIwfv4IqNCX8EZfvAMTAFpsDrwi0uO5W0pJMMcOKD0eT4smNbb+9eM2"
-            "6EPjd7nh5uMPiktm3JXXXPjfTacdieE8WsO+ddsV93dR5wT54mFG1myHAOBnAf4="
-        )
-        assert saml_integrator.signing_certificate == signing_cert
-        assert saml_integrator.certificates == [signing_cert, "cert1_content"]
-        endpoints = saml_integrator.endpoints
-        assert len(endpoints) == 2
-        assert endpoints[0].name == "SingleLogoutService"
-        assert endpoints[0].binding == "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
-        assert endpoints[0].url == "https://login.staging.ubuntu.com/+logout"
-        assert endpoints[0].response_url == "https://login.staging.ubuntu.com/example/"
-        assert endpoints[1].name == "SingleSignOnService"
-        assert endpoints[1].binding == "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
-        assert endpoints[1].url == "https://login.staging.ubuntu.com/saml/"
-        assert endpoints[1].response_url is None
+    metadata = Path("tests/unit/files/metadata_signed.xml").read_text(encoding="utf-8")
+    entity_id = "https://login.staging.ubuntu.com"
+    charm_state = MagicMock(
+        entity_id=entity_id,
+        fingerprint=(
+            "1C:73:51:f2:23:55:f8:3d:25:7e:65:56:dd:f1:a9:17:fe:d4:af"
+            ":dc:70:d2:a8:11:b3:2f:d2:ea:c4:6d:91:e7"
+        ),
+        metadata=metadata,
+    )
+    saml_integrator = SamlIntegrator(charm_state=charm_state)
+    signing_cert = (
+        "MIIFazCCA1OgAwIBAgIUWPY90f+xbkCWHVJXtwm2+9mZiIcwDQYJKoZIhvcNAQEL"
+        "BQAwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoM"
+        "GEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDAeFw0yMzA4MDkxNDI1NDVaFw0yNDA4"
+        "MDgxNDI1NDVaMEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEw"
+        "HwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwggIiMA0GCSqGSIb3DQEB"
+        "AQUAA4ICDwAwggIKAoICAQDDaJTOlLBVePVvenKbtq6B6vHNnvxLEA1NMmhZ9yvH"
+        "N/h0/FTph0iBf+VWyCY9M2CeMKggTIAhrVAXEALG7ImGl/lFKdfC/8eEXFtEMe4V"
+        "WAOC9qnb3dAViMAq5xMd6e5gwrcPSaDtOE8Up2OUfsHuf7GfocWtWh3beqW1FLE7"
+        "JBPcVKNZ6T8ap5fUHVCprfCk0yrPQ3ocJOWE0JHatqfahU34fWFTHWD1qfplL/Xf"
+        "mr9ayk+eey2FwsoloEtdpOMgitkeYpKNTh4btkQ4TEyKlG07+87l1b7niBeuEj1T"
+        "yqq87Kz6eHIarAlLmPHhBuM1/BQunyaVEfM0AXv2u/A8Uvz9njRoaWlZKHdlsEMq"
+        "hBzVCn+T7WnkxE3dGQDwgXbeDIOx1x/utR40UZeYUd6HUer4WtORNg1pBp2GeKp8"
+        "3gej/SjAhzqsB3ZdhPA47bDw21sp4ytTPCEvc2IsdErq7zIe5pUxkQKOe0R00qyd"
+        "69THdTqjvpo6oVQdEXauCisooWwxRAksUazqtaZUAwNB/pLqmE+kSFnsxEpn6BDH"
+        "6GVUFfMpzXUTsqBqK3j5QvHexVzLp3CyYicq1VjKghu5ICsIp+CGhLEEIBLJksJ8"
+        "IH6j9mHJ4W4qoLefBHNZDlxg2ZGDwEqs66gJVao5zQyEDjScUjVTrvfIZM3WY08L"
+        "5QIDAQABo1MwUTAdBgNVHQ4EFgQUW/f6Ya3dlETc60m8JFhZsZo4XLYwHwYDVR0j"
+        "BBgwFoAUW/f6Ya3dlETc60m8JFhZsZo4XLYwDwYDVR0TAQH/BAUwAwEB/zANBgkq"
+        "hkiG9w0BAQsFAAOCAgEAocRH2K+CWQFxMpJQvayEq7uU6dkdH2xE12Vg4wUm4/h+"
+        "hmngK6TlXqBHISpitlQlbqx1CsO3E9FeZGVA7erySh+lyoO9Hndhm7Fsj2U1P0MW"
+        "tkz81NOT975f0zTQ1KsdzTHkocV5dx869jD3ssUCkpxdTRF6EJmRLQoRfGEmxnuG"
+        "bynFcOUMZ7fxd79IsDy4tWcUjoV4jeWDiyi/LuuhVDr+AhI62Gl2MTdFLHTTRzak"
+        "IzIWmFVEdrfuDgg/RR4YYBoXrGSA0RLrpKpexb4kZd8/hvTtCcPghUuK6Q1iMT4q"
+        "hV2dKVFut/6IKLnD35Ol/fLLoy2CtnioUqx6v3MefxAptKpQM3ebgpv2UzIsIXdU"
+        "RQ9pfDlsyo1wdJ1wZNh6A5eerROsX3MKjLqUAiJh4v+ydeR3IyN3YckdadU6Wq+m"
+        "wnrVPI0nxrgLW/5srJ4cR4idEgmV8cRNJSqoaFPLyBoLk/cjq/yQAXcz23eWD6aD"
+        "qsOrRlyuKXQ6KEi/z6aIsiKNH5PPg9Fr3aH+cSnbTU7UNmJH/eOaYzaYMI1NiweU"
+        "Z5C+jLxosbIwfv4IqNCX8EZfvAMTAFpsDrwi0uO5W0pJMMcOKD0eT4smNbb+9eM2"
+        "6EPjd7nh5uMPiktm3JXXXPjfTacdieE8WsO+ddsV93dR5wT54mFG1myHAOBnAf4="
+    )
+    assert saml_integrator.signing_certificate == signing_cert
+    assert saml_integrator.certificates == [signing_cert, "cert1_content"]
+    endpoints = saml_integrator.endpoints
+    assert len(endpoints) == 2
+    assert endpoints[0].name == "SingleLogoutService"
+    assert endpoints[0].binding == "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
+    assert endpoints[0].url == "https://login.staging.ubuntu.com/+logout"
+    assert endpoints[0].response_url == "https://login.staging.ubuntu.com/example/"
+    assert endpoints[1].name == "SingleSignOnService"
+    assert endpoints[1].binding == "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
+    assert endpoints[1].url == "https://login.staging.ubuntu.com/saml/"
+    assert endpoints[1].response_url is None
 
 
-@patch("urllib.request.urlopen")
-def test_saml_with_valid_tampered_signed_metadata(urlopen_mock):
+def test_saml_with_valid_tampered_signed_metadata():
     """
     arrange: mock the metadata contents so that they invalid.
     act: access the metadata properties.
     assert: an exception is raised.
     """
-    with open("tests/unit/files/metadata_signed_tampered.xml", "rb") as metadata:
-        urlopen_result_mock = get_urlopen_result_mock(200, metadata.read())
-        urlopen_result_mock.__enter__.return_value = urlopen_result_mock
-        urlopen_mock.return_value = urlopen_result_mock
+    metadata = Path("tests/unit/files/metadata_signed_tampered.xml").read_text(encoding="utf-8")
 
-        entity_id = "https://login.staging.ubuntu.com"
-        metadata_url = "https://login.staging.ubuntu.com/saml/metadata"
-        charm_state = MagicMock(
-            entity_id=entity_id,
-            fingerprint=(
-                "1c:73:51:f2:23:55:f8:3d:25:7e:65:56:dd:f1:a9:17:fe:d4:af"
-                ":dc:70:d2:a8:11:b3:2f:d2:ea:c4:6d:91:e7"
-            ),
-            metadata_url=metadata_url,
-        )
-        saml_integrator = SamlIntegrator(charm_state=charm_state)
-        with pytest.raises(CharmConfigInvalidError):
-            saml_integrator.tree
+    entity_id = "https://login.staging.ubuntu.com"
+    charm_state = MagicMock(
+        entity_id=entity_id,
+        fingerprint=(
+            "1c:73:51:f2:23:55:f8:3d:25:7e:65:56:dd:f1:a9:17:fe:d4:af"
+            ":dc:70:d2:a8:11:b3:2f:d2:ea:c4:6d:91:e7"
+        ),
+        metadata=metadata,
+    )
+    saml_integrator = SamlIntegrator(charm_state=charm_state)
+    with pytest.raises(CharmConfigInvalidError):
+        saml_integrator.tree
 
 
-@patch("urllib.request.urlopen")
-def test_saml_with_valid_signed_metadata_not_matching_fingerprint(urlopen_mock):
+def test_saml_with_valid_signed_metadata_not_matching_fingerprint():
     """
     arrange: mock the metadata contents so that they invalid and set an invalid fingerprint.
     act: access the metadata properties.
-    assert: the properties are populated as defined in the metadata.
+    assert: the properties are po
+    pulated as defined in the metadata.
     """
-    with open("tests/unit/files/metadata_signed.xml", "rb") as metadata:
-        urlopen_result_mock = get_urlopen_result_mock(200, metadata.read())
-        urlopen_result_mock.__enter__.return_value = urlopen_result_mock
-        urlopen_mock.return_value = urlopen_result_mock
+    metadata = Path("tests/unit/files/metadata_signed.xml").read_text(encoding="utf-8")
 
-        entity_id = "https://login.staging.ubuntu.com"
-        metadata_url = "https://login.staging.ubuntu.com/saml/metadata"
-        charm_state = MagicMock(
-            entity_id=entity_id,
-            fingerprint="invalid_fingerprint",
-            metadata_url=metadata_url,
-        )
-        saml_integrator = SamlIntegrator(charm_state=charm_state)
-        with pytest.raises(CharmConfigInvalidError):
-            saml_integrator.tree
+    entity_id = "https://login.staging.ubuntu.com"
+    charm_state = MagicMock(
+        entity_id=entity_id,
+        fingerprint="invalid_fingerprint",
+        metadata=metadata,
+    )
+    saml_integrator = SamlIntegrator(charm_state=charm_state)
+    with pytest.raises(CharmConfigInvalidError):
+        saml_integrator.tree
 
 
-@patch("urllib.request.urlopen")
-def test_saml_with_valid_unsigned_metadata(urlopen_mock):
+def test_saml_with_valid_unsigned_metadata():
     """
     arrange: mock the metadata contents so that they invalid.
     act: access the metadata properties.
     assert: the properties are populated as defined in the metadata.
     """
-    with open("tests/unit/files/metadata_unsigned.xml", "rb") as metadata:
-        urlopen_result_mock = get_urlopen_result_mock(200, metadata.read())
-        urlopen_result_mock.__enter__.return_value = urlopen_result_mock
-        urlopen_mock.return_value = urlopen_result_mock
+    metadata = Path("tests/unit/files/metadata_unsigned.xml").read_text(encoding="utf-8")
 
-        entity_id = "https://login.staging.ubuntu.com"
-        metadata_url = "https://login.staging.ubuntu.com/saml/metadata"
-        charm_state = MagicMock(
-            entity_id=entity_id,
-            fingerprint="",
-            metadata_url=metadata_url,
-        )
-        saml_integrator = SamlIntegrator(charm_state=charm_state)
-        assert saml_integrator.certificates == ["cert1_content"]
-        endpoints = saml_integrator.endpoints
-        assert len(endpoints) == 2
-        assert endpoints[0].name == "SingleLogoutService"
-        assert endpoints[0].binding == "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Post"
-        assert endpoints[0].url == "https://login.staging.ubuntu.com/+logout"
-        assert endpoints[0].response_url == "https://login.staging.ubuntu.com/example/"
-        assert endpoints[1].name == "SingleSignOnService"
-        assert endpoints[1].binding == "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Post"
-        assert endpoints[1].url == "https://login.staging.ubuntu.com/saml/"
-        assert endpoints[1].response_url is None
+    entity_id = "https://login.staging.ubuntu.com"
+    charm_state = MagicMock(
+        entity_id=entity_id,
+        fingerprint="",
+        metadata=metadata,
+    )
+    saml_integrator = SamlIntegrator(charm_state=charm_state)
+    assert saml_integrator.certificates == ["cert1_content"]
+    endpoints = saml_integrator.endpoints
+    assert len(endpoints) == 2
+    assert endpoints[0].name == "SingleLogoutService"
+    assert endpoints[0].binding == "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Post"
+    assert endpoints[0].url == "https://login.staging.ubuntu.com/+logout"
+    assert endpoints[0].response_url == "https://login.staging.ubuntu.com/example/"
+    assert endpoints[1].name == "SingleSignOnService"
+    assert endpoints[1].binding == "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Post"
+    assert endpoints[1].url == "https://login.staging.ubuntu.com/saml/"
+    assert endpoints[1].response_url is None
 
 
-@patch("urllib.request.urlopen")
-def test_saml_with_valid_unsigned_metadata_non_utf8(urlopen_mock):
+def test_saml_with_valid_unsigned_metadata_non_utf8():
     """
     arrange: mock the metadata contents so that they invalid.
     act: access the metadata properties.
     assert: the properties are populated as defined in the metadata.
     """
-    with open("tests/unit/files/non_utf8_metadata_unsigned.xml", "rb") as metadata:
-        urlopen_result_mock = get_urlopen_result_mock(200, metadata.read())
-        urlopen_result_mock.__enter__.return_value = urlopen_result_mock
-        urlopen_mock.return_value = urlopen_result_mock
+    metadata = Path("tests/unit/files/non_utf8_metadata_unsigned.xml").read_text(encoding="utf-8")
 
-        entity_id = "https://accounts.google.com/o/saml2?idpid=C03oypjtr"
-        metadata_url = "https://accounts.google.com/samlrp/metadata?idpid=C03oypjtr"
-        charm_state = MagicMock(
-            entity_id=entity_id,
-            fingerprint="",
-            metadata_url=metadata_url,
-        )
-        saml_integrator = SamlIntegrator(charm_state=charm_state)
-        certificate = (
-            "MIIDdDCCAlygAwIBAgIGAYdLBPyWMA0GCSqGSIb3DQEBCwUAMHsxFDASBgNVBAoTC0dvb2dsZSBJ"
-            "bmMuMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MQ8wDQYDVQQDEwZHb29nbGUxGDAWBgNVBAsTD0dv"
-            "b2dsZSBGb3IgV29yazELMAkGA1UEBhMCVVMxEzARBgNVBAgTCkNhbGlmb3JuaWEwHhcNMjMwNDA0"
-            "MDY0NzA5WhcNMjgwNDAyMDY0NzA5WjB7MRQwEgYDVQQKEwtHb29nbGUgSW5jLjEWMBQGA1UEBxMN"
-            "TW91bnRhaW4gVmlldzEPMA0GA1UEAxMGR29vZ2xlMRgwFgYDVQQLEw9Hb29nbGUgRm9yIFdvcmsx"
-            "CzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpDYWxpZm9ybmlhMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A"
-            "MIIBCgKCAQEApl6vmP6rt86m6I3dojHeT7bodIlDU3UnE2y1Hpqc6xlq0Kxv3ZcVrZX1dX/UC4NY"
-            "CTlumUrEoVzERKRU1aGqBuk9QqvMpkf25jiWEetDly7IVJAq8behjq+801KzU3Kn1s830+czzQuH"
-            "oVA9KlWwL6FSbCjmNKlAQ8qqcyQ3C1HlVF0x489/kfgZFw6sSX1sTZHgG0vw2E8xGdjRdtVVEgQG"
-            "uWzLvcpWAPAK6IqzY5e9xETXN8au04SqnVWfUi19f4w8kCh3T8LIakmvm09lxYajndKCQvYrPnq+"
-            "YpVwHiufnHxkVMb4claFFgX+gNDyEWbGDIi8yOQnKeUHnpCKGQIDAQABMA0GCSqGSIb3DQEBCwUA"
-            "A4IBAQBZJnZzQilSlH3N2UCoJ1G9Me47NdZIs1HyQZNMtzbXwS+Z5Ek05loKFj75D3R094dtn4RC"
-            "1pM5BQjBProMG5UbtQKVKbM8SjQgj23UWuuc6YXDok9lqtWuGwpOSNYUU75K/7vdVCFdG2urtms2"
-            "ueZ2D8bA3nDhsgHAhc6YJM3TqatcFHRGTNlwkKl71GYMWYM3JKNEZAfU7zhjicXYhW7t3+Hj6TJC"
-            "ChYw2B+hfOv0W324BZyyZW8X3m5CWVlCWxBKfIo3NJ+gg/dGbkuPIbzdV197LSuxkArm/7rMbxwe"
-            "KNL8a7w5HN3iCi27GlKpmj4n5uMnDpRDk81hrvyew2Rp"
-        )
-        assert saml_integrator.certificates == [certificate]
-        endpoints = saml_integrator.endpoints
-        assert len(endpoints) == 2
-        assert endpoints[0].name == "SingleSignOnService"
-        assert endpoints[0].binding == "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
-        assert endpoints[0].url == "https://accounts.google.com/o/saml2/idp?idpid=C03oypjtr"
-        assert endpoints[0].response_url is None
-        assert endpoints[1].name == "SingleSignOnService"
-        assert endpoints[1].binding == "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
-        assert endpoints[1].url == "https://accounts.google.com/o/saml2/idp?idpid=C03oypjtr"
-        assert endpoints[1].response_url is None
+    entity_id = "https://accounts.google.com/o/saml2?idpid=C03oypjtr"
+    charm_state = MagicMock(
+        entity_id=entity_id,
+        fingerprint="",
+        metadata=metadata,
+    )
+    saml_integrator = SamlIntegrator(charm_state=charm_state)
+    certificate = (
+        "MIIDdDCCAlygAwIBAgIGAYdLBPyWMA0GCSqGSIb3DQEBCwUAMHsxFDASBgNVBAoTC0dvb2dsZSBJ"
+        "bmMuMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MQ8wDQYDVQQDEwZHb29nbGUxGDAWBgNVBAsTD0dv"
+        "b2dsZSBGb3IgV29yazELMAkGA1UEBhMCVVMxEzARBgNVBAgTCkNhbGlmb3JuaWEwHhcNMjMwNDA0"
+        "MDY0NzA5WhcNMjgwNDAyMDY0NzA5WjB7MRQwEgYDVQQKEwtHb29nbGUgSW5jLjEWMBQGA1UEBxMN"
+        "TW91bnRhaW4gVmlldzEPMA0GA1UEAxMGR29vZ2xlMRgwFgYDVQQLEw9Hb29nbGUgRm9yIFdvcmsx"
+        "CzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpDYWxpZm9ybmlhMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A"
+        "MIIBCgKCAQEApl6vmP6rt86m6I3dojHeT7bodIlDU3UnE2y1Hpqc6xlq0Kxv3ZcVrZX1dX/UC4NY"
+        "CTlumUrEoVzERKRU1aGqBuk9QqvMpkf25jiWEetDly7IVJAq8behjq+801KzU3Kn1s830+czzQuH"
+        "oVA9KlWwL6FSbCjmNKlAQ8qqcyQ3C1HlVF0x489/kfgZFw6sSX1sTZHgG0vw2E8xGdjRdtVVEgQG"
+        "uWzLvcpWAPAK6IqzY5e9xETXN8au04SqnVWfUi19f4w8kCh3T8LIakmvm09lxYajndKCQvYrPnq+"
+        "YpVwHiufnHxkVMb4claFFgX+gNDyEWbGDIi8yOQnKeUHnpCKGQIDAQABMA0GCSqGSIb3DQEBCwUA"
+        "A4IBAQBZJnZzQilSlH3N2UCoJ1G9Me47NdZIs1HyQZNMtzbXwS+Z5Ek05loKFj75D3R094dtn4RC"
+        "1pM5BQjBProMG5UbtQKVKbM8SjQgj23UWuuc6YXDok9lqtWuGwpOSNYUU75K/7vdVCFdG2urtms2"
+        "ueZ2D8bA3nDhsgHAhc6YJM3TqatcFHRGTNlwkKl71GYMWYM3JKNEZAfU7zhjicXYhW7t3+Hj6TJC"
+        "ChYw2B+hfOv0W324BZyyZW8X3m5CWVlCWxBKfIo3NJ+gg/dGbkuPIbzdV197LSuxkArm/7rMbxwe"
+        "KNL8a7w5HN3iCi27GlKpmj4n5uMnDpRDk81hrvyew2Rp"
+    )
+    assert saml_integrator.certificates == [certificate]
+    endpoints = saml_integrator.endpoints
+    assert len(endpoints) == 2
+    assert endpoints[0].name == "SingleSignOnService"
+    assert endpoints[0].binding == "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
+    assert endpoints[0].url == "https://accounts.google.com/o/saml2/idp?idpid=C03oypjtr"
+    assert endpoints[0].response_url is None
+    assert endpoints[1].name == "SingleSignOnService"
+    assert endpoints[1].binding == "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+    assert endpoints[1].url == "https://accounts.google.com/o/saml2/idp?idpid=C03oypjtr"
+    assert endpoints[1].response_url is None
 
 
-@patch("urllib.request.urlopen")
-def test_saml_with_metadata_with_default_namespaces(urlopen_mock):
+def test_saml_with_metadata_with_default_namespaces():
     """
     arrange: mock the metadata with XML default namespaces.
     act: access the metadata properties.
     assert: the properties are populated as defined in the metadata.
     """
-    with open("tests/unit/files/metadata_default_namespaces.xml", "rb") as metadata:
-        urlopen_result_mock = get_urlopen_result_mock(200, metadata.read())
-        urlopen_result_mock.__enter__.return_value = urlopen_result_mock
-        urlopen_mock.return_value = urlopen_result_mock
+    metadata = Path("tests/unit/files/metadata_default_namespaces.xml").read_text(encoding="utf-8")
 
-        entity_id = "https://saml.canonical.test/metadata"
-        metadata_url = "https://saml.canonical.test/metadata"
-        charm_state = MagicMock(
-            entity_id=entity_id,
-            fingerprint="",
-            metadata_url=metadata_url,
-        )
-        saml_integrator = SamlIntegrator(charm_state=charm_state)
-        endpoints = saml_integrator.endpoints
-        assert len(endpoints) == 2
-        assert endpoints[0].name == "SingleSignOnService"
-        assert endpoints[0].binding == "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
-        assert endpoints[0].url == "https://saml.canonical.test/sso"
-        assert endpoints[0].response_url is None
-        assert endpoints[1].name == "SingleSignOnService"
-        assert endpoints[1].binding == "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
-        assert endpoints[1].url == "https://saml.canonical.test/sso"
-        assert endpoints[1].response_url is None
+    entity_id = "https://saml.canonical.test/metadata"
+    charm_state = MagicMock(
+        entity_id=entity_id,
+        fingerprint="",
+        metadata=metadata,
+    )
+    saml_integrator = SamlIntegrator(charm_state=charm_state)
+    endpoints = saml_integrator.endpoints
+    assert len(endpoints) == 2
+    assert endpoints[0].name == "SingleSignOnService"
+    assert endpoints[0].binding == "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
+    assert endpoints[0].url == "https://saml.canonical.test/sso"
+    assert endpoints[0].response_url is None
+    assert endpoints[1].name == "SingleSignOnService"
+    assert endpoints[1].binding == "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+    assert endpoints[1].url == "https://saml.canonical.test/sso"
+    assert endpoints[1].response_url is None


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
Support configuring the metadata directly, adding a new config option

### Rationale

<!-- The reason the change is needed -->
Closes #89 

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
