### PR TITLE
Ensure correct packages are always installed

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -43,7 +43,7 @@ class SamlIntegratorOperatorCharm(ops.CharmBase):
         self.framework.observe(self.on.update_status, self._on_update_status)
 
     def _on_install(self, _) -> None:
-        """Install needed apt packages."""
+        """Handle the install event."""
         self.unit.status = ops.MaintenanceStatus("Installing packages")
         self._install_apt_packages()
         self.unit.status = ops.ActiveStatus()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -50,6 +50,58 @@ def test_misconfigured_charm_reaches_blocked_status():
     assert harness.model.unit.status.name == ops.BlockedStatus().name
 
 
+@patch.object(apt, "add_package")
+def test_config_changed_try_except(apt_add_package_mock):
+    """
+    arrange: set up a charm.
+    act: trigger a config-changed that triggers an ImportError.
+    assert: the charm executes _update_relations after installing packages.
+    """
+    metadata = Path("tests/unit/files/metadata_unsigned.xml").read_text(encoding="utf-8")
+    harness = Harness(SamlIntegratorOperatorCharm)
+    entity_id = "https://login.staging.ubuntu.com"
+    harness.update_config(
+        {
+            "entity_id": entity_id,
+            "metadata": metadata,
+        }
+    )
+    harness.begin()
+    with patch("charm.SamlIntegratorOperatorCharm._update_relations") as update_relations_mock:
+        # When we call update_relations initially, trigger an ImportError so
+        # we attempt to install the packages.
+        update_relations_mock.side_effect = [ImportError("Packages not installed"), None]
+        harness.charm.on.config_changed.emit()
+        # And confirm we've installed the required packages as well.
+        apt_add_package_mock.assert_called_once_with(
+            ["libssl-dev", "libxml2", "libxslt1-dev"], update_cache=True
+        )
+        # We've called update_relations twice, once triggering the ImportError
+        # and once after installing the packages it requires.
+        assert update_relations_mock.call_count == 2
+
+
+def test_update_status():
+    """
+    arrange: set up a charm.
+    act: trigger an update status with the required configs.
+    assert: the charm executes _update_relations.
+    """
+    metadata = Path("tests/unit/files/metadata_unsigned.xml").read_text(encoding="utf-8")
+    harness = Harness(SamlIntegratorOperatorCharm)
+    entity_id = "https://login.staging.ubuntu.com"
+    harness.update_config(
+        {
+            "entity_id": entity_id,
+            "metadata": metadata,
+        }
+    )
+    harness.begin()
+    with patch("charm.SamlIntegratorOperatorCharm._update_relations") as update_relations_mock:
+        harness.charm.on.update_status.emit()
+        assert update_relations_mock.called_once()
+
+
 def test_charm_reaches_active_status():
     """
     arrange: set up a charm.

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -39,32 +39,6 @@ def test_libs_installed(apt_add_package_mock):
     )
 
 
-@patch.object(apt, "add_package")
-def test_libs_installed_on_upgrade(apt_add_package_mock):
-    """
-    arrange: set up a charm.
-    act: trigger the upgrade-charm event.
-    assert: the charm installs required packages.
-    """
-    harness = Harness(SamlIntegratorOperatorCharm)
-    entity_id = "https://login.staging.ubuntu.com"
-    metadata_url = "https://login.staging.ubuntu.com/saml/metadata"
-    harness.update_config(
-        {
-            "entity_id": entity_id,
-            "metadata_url": metadata_url,
-        }
-    )
-    harness.begin()
-    # First confirm no packages have been installed.
-    apt_add_package_mock.assert_not_called()
-    harness.charm.on.upgrade_charm.emit()
-    # And now confirm we've installed the required packages.
-    apt_add_package_mock.assert_called_once_with(
-        ["libssl-dev", "libxml2", "libxslt1-dev"], update_cache=True
-    )
-
-
 def test_misconfigured_charm_reaches_blocked_status():
     """
     arrange: set up a charm.


### PR DESCRIPTION
Applicable spec: N/A

### Overview

Ensure the correct packages are installed in all cases. In some deployments if the container restarts we may get a `config-changed` event without a `upgrade-charm`.

### Rationale

Ensure correct packages are installed at the point that we need them.

### Juju Events Changes

No need to observe the `upgrade-charm` event, we just have a try/except block installing packages when they're needed.

### Module Changes

N/A

### Library Changes

N/A

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
