### PR TITLE
Reenable interface tests

### DIFF
--- a/tests/interface/test_saml.py
+++ b/tests/interface/test_saml.py
@@ -1,11 +1,14 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
-import pytest
 from interface_tester import InterfaceTester
 
 
-# https://github.com/canonical/pytest-interface-tester/issues/27
-@pytest.mark.skip
+# Interface tests are centrally hosted at https://github.com/canonical/charm-relation-interfaces.
+# this fixture is used by the test runner of charm-relation-interfaces to test saml's compliance
+# with the interface specifications.
+# DO NOT MOVE OR RENAME THIS FIXTURE! If you need to, you'll need to open a PR on
+# https://github.com/canonical/charm-relation-interfaces and change saml's test configuration
+# to include the new identifier/location.
 def test_saml_v0_interface(interface_tester: InterfaceTester):
     interface_tester.configure(
         interface_name="saml",


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
Reenable interface tests now that https://github.com/canonical/pytest-interface-tester/issues/27 has been fixed

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
