### PR TITLE
Add typing compatible with python 3.8

### DIFF
--- a/src/saml.py
+++ b/src/saml.py
@@ -99,7 +99,7 @@ class SamlIntegrator:  # pylint: disable=import-outside-toplevel
         }
 
     @cached_property
-    def signing_certificate(self) -> str | None:
+    def signing_certificate(self) -> Optional[str]:
         """Return the signing certificate for the metadata, if any."""
         tree = self._read_tree()
         signing_certificates = tree.xpath(


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
