### PR TITLE
Update status on relation-created and update-status events

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -43,13 +43,17 @@ class SamlIntegratorOperatorCharm(ops.CharmBase):
         """Handle a change to the saml relation."""
         # A new charm will be instantiated hence, the information will be fetched again.
         # The relation databags are rewritten in case there are changes.
+        self.unit.status = ops.MaintenanceStatus("Update integrations")
         self._update_relations()
+        self.unit.status = ops.ActiveStatus()
 
     def _on_update_status(self, _) -> None:
         """Handle the update status event."""
         # A new charm will be instantiated hence, the information will be fetched again.
         # The relation databags are rewritten in case there are changes.
+        self.unit.status = ops.MaintenanceStatus("Update integrations")
         self._update_relations()
+        self.unit.status = ops.ActiveStatus()
 
     def _on_config_changed(self, _) -> None:
         """Handle changes in configuration."""


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Update status on relation-created and update-status events.

### Rationale

Sometimes, the status may get stuck in the maintenance state. Allowing more events to refresh the status should help mitigate this issue.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
